### PR TITLE
simplify pip installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ class my_build_py(build_py):
       # mkpath is a distutils helper to create directories
       self.mkpath(target_dir)
       
-      ## download the zip directory from url a
+      ## download the zip directory from url 
       if (sysconfig.get_platform() == 'linux-x86_64'):
         r = requests.get("https://test.openmodelica.org/jenkins/job/OMSimulator/job/master/lastSuccessfulBuild/artifact/OMSimulator-linux-amd64*/*zip*/archive.zip")
       elif (sysconfig.get_platform() == 'mingw'):


### PR DESCRIPTION
### Purpose

This PR simplifies `pip` installation of OMSimulator by downloading the prebuilt binaries from the artifacts https://test.openmodelica.org/jenkins/job/OMSimulator/job/master/lastSuccessfulBuild/artifact/  depending on the platform.  This simplifies the pip installation much easier and avoid  tool dependencies when building the package.
 