### PR TITLE
use shutil package to unzip the files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,53 +53,55 @@ os.mkdir(topdir)
 
 # overrride build_py, for compiling and copying the dlls
 class my_build_py(build_py):
-  def run(self):
-    if not self.dry_run:
-      target_dir = os.path.join(self.build_lib, 'OMSimulator')
+  def fetch_oms(self):
+    target_dir = os.path.join(self.build_lib, 'OMSimulator')
 
-      # mkpath is a distutils helper to create directories
-      self.mkpath(target_dir)
+    # mkpath is a distutils helper to create directories
+    self.mkpath(target_dir)
 
-      # download the zip directory from url
-      if (sysconfig.get_platform() == 'linux-x86_64'):
-        r = requests.get('https://test.openmodelica.org/jenkins/job/OMSimulator/job/master/lastSuccessfulBuild/artifact/OMSimulator-linux-amd64*/*zip*/archive.zip')
-      elif (sysconfig.get_platform() == 'mingw'):
-        r = requests.get('https://test.openmodelica.org/jenkins/job/OMSimulator/job/master/lastSuccessfulBuild/artifact/OMSimulator-mingw64*/*zip*/archive.zip')
-      elif (sysconfig.get_platform() == 'win-amd64'):
-        r = requests.get('https://test.openmodelica.org/jenkins/job/OMSimulator/job/master/lastSuccessfulBuild/artifact/OMSimulator-win64*/*zip*/archive.zip')
+    # download the zip directory from url
+    if (sysconfig.get_platform() == 'linux-x86_64'):
+      r = requests.get('https://test.openmodelica.org/jenkins/job/OMSimulator/job/master/lastSuccessfulBuild/artifact/OMSimulator-linux-amd64*/*zip*/archive.zip')
+    elif (sysconfig.get_platform() == 'mingw'):
+      r = requests.get('https://test.openmodelica.org/jenkins/job/OMSimulator/job/master/lastSuccessfulBuild/artifact/OMSimulator-mingw64*/*zip*/archive.zip')
+    elif (sysconfig.get_platform() == 'win-amd64'):
+      r = requests.get('https://test.openmodelica.org/jenkins/job/OMSimulator/job/master/lastSuccessfulBuild/artifact/OMSimulator-win64*/*zip*/archive.zip')
 
-      z = zipfile.ZipFile(io.BytesIO(r.content))
+    z = zipfile.ZipFile(io.BytesIO(r.content))
 
-      zipInfo = z.namelist()[0]
-      dirname, extension = os.path.splitext(zipInfo)
+    zipInfo = z.namelist()[0]
+    dirname, extension = os.path.splitext(zipInfo)
 
-      tempDir = tempfile.gettempdir()
-      zipFilePath = os.path.join(tempDir, zipInfo)
+    tempDir = tempfile.gettempdir()
+    zipFilePath = os.path.join(tempDir, zipInfo)
 
-      if os.path.exists(zipFilePath):
-        os.remove(zipFilePath)
-
-      # copy the zip file in temp directory
-      z.extractall(tempDir)
-      z.close()
-
-      zipDir = os.path.join(tempDir, dirname)
-      # remove zip directory if exists
-      if os.path.isdir(zipDir):
-        shutil.rmtree(zipDir)
-
-      # unzip the zip file
-      shutil.unpack_archive(zipFilePath, zipDir)
-
-      # copy OMSimulator package to root directory
-      copy_tree(os.path.join(zipDir, 'lib/OMSimulator'), target_dir)
-
-      # remove the zip directory after copying the files
-      shutil.rmtree(zipDir)
-
-      # remove the zip file
+    if os.path.exists(zipFilePath):
       os.remove(zipFilePath)
 
+    # copy the zip file in temp directory
+    z.extractall(tempDir)
+    z.close()
+
+    zipDir = os.path.join(tempDir, dirname)
+    # remove zip directory if exists
+    if os.path.isdir(zipDir):
+      shutil.rmtree(zipDir)
+
+    # unzip the zip file
+    shutil.unpack_archive(zipFilePath, zipDir)
+
+    # copy OMSimulator package to root directory
+    copy_tree(os.path.join(zipDir, 'lib/OMSimulator'), target_dir)
+
+    # remove the zip directory after copying the files
+    shutil.rmtree(zipDir)
+
+    # remove the zip file
+    os.remove(zipFilePath)
+
+  def run(self):
+    if not self.dry_run:
+      self.fetch_oms()
     build_py.run(self)
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-__license__ = """
+__license__ = '''
 This file is part of OpenModelica.
 Copyright (c) 1998-CurrentYear, Open Source Modelica Consortium (OSMC),
 c/o Linköpings universitet, Department of Computer and Information Science,
@@ -23,90 +23,95 @@ even the implied warranty of  MERCHANTABILITY or FITNESS
 FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
 IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
 See the full OSMC Public License conditions for more details.
-"""
-__author__ = "Open Source Modelica Consortium (OSMC)"
-__maintainer__ = "https://openmodelica.org"
-__status__ = "Production"
+'''
+
+__author__ = 'Open Source Modelica Consortium (OSMC)'
+__maintainer__ = 'https://openmodelica.org'
+__status__ = 'Production'
 
 
-from setuptools import setup
-from distutils.command.build_py import build_py
-from distutils.file_util import copy_file
-from distutils.dir_util import copy_tree
-import os, sysconfig
+import io
+import os
+import shutil
+import sysconfig
 import tempfile
-import requests, zipfile, io, shutil
+import zipfile
+from distutils.command.build_py import build_py
+from distutils.dir_util import copy_tree
+from distutils.file_util import copy_file
 
+import requests
+from setuptools import setup
 
-topdir= os.path.join(os.getcwd(), 'OMSimulator')
-## check if directory exist and remove 
+topdir = os.path.join(os.getcwd(), 'OMSimulator')
+# check if directory exist and remove
 if os.path.isdir(topdir):
   os.rmdir(topdir)
 
-## create a dummy directory, so that setuptools creates the package directory
+# create a dummy directory, so that setuptools creates the package directory
 os.mkdir(topdir)
 
-## overrride build_py, for compiling and copying the dlls
+# overrride build_py, for compiling and copying the dlls
 class my_build_py(build_py):
   def run(self):
     if not self.dry_run:
       target_dir = os.path.join(self.build_lib, 'OMSimulator')
-      
+
       # mkpath is a distutils helper to create directories
       self.mkpath(target_dir)
-      
-      ## download the zip directory from url 
+
+      # download the zip directory from url
       if (sysconfig.get_platform() == 'linux-x86_64'):
-        r = requests.get("https://test.openmodelica.org/jenkins/job/OMSimulator/job/master/lastSuccessfulBuild/artifact/OMSimulator-linux-amd64*/*zip*/archive.zip")
+        r = requests.get('https://test.openmodelica.org/jenkins/job/OMSimulator/job/master/lastSuccessfulBuild/artifact/OMSimulator-linux-amd64*/*zip*/archive.zip')
       elif (sysconfig.get_platform() == 'mingw'):
-        r = requests.get("https://test.openmodelica.org/jenkins/job/OMSimulator/job/master/lastSuccessfulBuild/artifact/OMSimulator-mingw64*/*zip*/archive.zip")
-      elif (sysconfig.get_platform() == "win-amd64"):
-        r = requests.get("https://test.openmodelica.org/jenkins/job/OMSimulator/job/master/lastSuccessfulBuild/artifact/OMSimulator-win64*/*zip*/archive.zip")
+        r = requests.get('https://test.openmodelica.org/jenkins/job/OMSimulator/job/master/lastSuccessfulBuild/artifact/OMSimulator-mingw64*/*zip*/archive.zip')
+      elif (sysconfig.get_platform() == 'win-amd64'):
+        r = requests.get('https://test.openmodelica.org/jenkins/job/OMSimulator/job/master/lastSuccessfulBuild/artifact/OMSimulator-win64*/*zip*/archive.zip')
 
       z = zipfile.ZipFile(io.BytesIO(r.content))
-      
+
       zipInfo = z.namelist()[0]
       dirname, extension = os.path.splitext(zipInfo)
 
       tempDir = tempfile.gettempdir()
       zipFilePath = os.path.join(tempDir, zipInfo)
-      
+
       if os.path.exists(zipFilePath):
         os.remove(zipFilePath)
 
-      ## copy the zip file in temp directory
+      # copy the zip file in temp directory
       z.extractall(tempDir)
       z.close()
 
       zipDir = os.path.join(tempDir, dirname)
-      #remove zip directory if exists
+      # remove zip directory if exists
       if os.path.isdir(zipDir):
         shutil.rmtree(zipDir)
 
-      ## unzip the zip file
+      # unzip the zip file
       shutil.unpack_archive(zipFilePath, zipDir)
 
       # copy OMSimulator package to root directory
-      copy_tree(os.path.join(zipDir,"lib/OMSimulator"), target_dir)
+      copy_tree(os.path.join(zipDir, 'lib/OMSimulator'), target_dir)
 
-      ## remove the zip directory after copying the files
+      # remove the zip directory after copying the files
       shutil.rmtree(zipDir)
-      ## remove the zip file
+
+      # remove the zip file
       os.remove(zipFilePath)
-      print("### Build OMSimulator successful ###")
 
     build_py.run(self)
 
 setup(
-      name="OMSimulator",
-      version="latest",
-      description="OMSimulator-Python API Interface",
-      author="Open Source Modelica Consortium (OSMC)",
-      author_email="openmodelicadevelopers@ida.liu.se",
-      license="BSD, OSMC-PL 1.2, GPL (user's choice)",
-      url="http://openmodelica.org/",
-      install_requires=["requests"],
-      packages=["OMSimulator"],
-      cmdclass={'build_py': my_build_py},
+      name = 'OMSimulator',
+      version = 'latest',
+      description = 'OMSimulator-Python API Interface',
+      author = 'Open Source Modelica Consortium (OSMC)',
+      author_email = 'openmodelicadevelopers@ida.liu.se',
+      license = "BSD, OSMC-PL 1.2, GPL (user's choice)",
+      url = 'http://openmodelica.org/',
+      install_requires = ['requests'],
+      packages = ['OMSimulator'],
+      cmdclass = {'build_py': my_build_py},
       zip_safe = False
       )

--- a/setup.py
+++ b/setup.py
@@ -76,9 +76,7 @@ class my_build_py(build_py):
 
       ## copy the zip file in temp directory
       z.extractall(tempDir)
-      
-      ## read the zip file
-      file = zipfile.ZipFile(zipFilePath)
+      z.close()
 
       zipDir = os.path.join(tempDir, dirname)
       #remove zip directory if exists
@@ -86,13 +84,11 @@ class my_build_py(build_py):
         shutil.rmtree(zipDir)
 
       ## unzip the zip file
-      file.extractall(zipDir)
+      shutil.unpack_archive(zipFilePath, zipDir)
 
       # copy OMSimulator package to root directory
       copy_tree(os.path.join(zipDir,"lib/OMSimulator"), target_dir)
-      z.close()
-      file.close()
-      
+
       ## remove the zip directory after copying the files
       shutil.rmtree(zipDir)
       ## remove the zip file


### PR DESCRIPTION
### Purpose

This PR fixes the unpacking of `tar.gz` in linux platform, Use `shutil.unpack_archive` to support both `zip `and `tar.gz` format